### PR TITLE
ci: add github workflow for building jekyll site

### DIFF
--- a/.github/workflows/build-jekyll.yml
+++ b/.github/workflows/build-jekyll.yml
@@ -1,0 +1,25 @@
+name: Build and deploy Jekyll site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  github-pages:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+
+        # Use GitHub Actions' cache to shorten build times and decrease load on servers
+      - uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - uses: jeffreytse/jekyll-deploy-action@v0.1.0
+        with:
+          provider: 'github'
+          token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Hi @tarkil 

Here is a CI ([jekyll-deploy-action](https://github.com/jeffreytse/jekyll-deploy-action) and also can give a star if you like) to automatically build and deploy Jekyll site on Github Pages for you, especially for using custom plugins.

The steps I suggest you as bellow:

1. Create a  `gh-pages` branch. 
```
git checkout --orphan gh-pages
git rm -rf .
git commit --allow-empty -m "initial commit"
git push origin gh-pages
```

(i.e. The `gh-pages` branch is only for the site static files and the `master` branch is for source code)

2. After this, create a [Personal Token](https://github.com/settings/tokens) with repos permissions for CI.
* Go to your repository’s Settings and then the Secrets tab.
* Create a token named `GH_TOKEN` (important). Give it a value using the value copied above.
